### PR TITLE
Fix constants alias and clan data tests

### DIFF
--- a/Mygames/HCshinobi/HCshinobi/core/constants.py
+++ b/Mygames/HCshinobi/HCshinobi/core/constants.py
@@ -37,6 +37,8 @@ MISSION_DEFINITIONS_FILE = "mission_definitions.json" # Resides in MISSIONS_SUBD
 
 # --- Core Data Filenames (Relative to DATA_DIR or subdir) --- 
 CLANS_FILE = "clans.json"  # Legacy format - being phased out
+# Backwards compatibility alias used by older tests
+CLAN_FILE = CLANS_FILE
 NPC_FILE = "npcs.json"  # Resides in DATA_DIR root
 MODIFIERS_FILE = "modifiers.json"  # Resides in DATA_DIR root
 CLAN_POPULATION_FILE = "clan_populations.json"


### PR DESCRIPTION
## Summary
- add CLAN_FILE alias for older tests
- implement Mission dataclass stub
- add synchronous initialize method in ClanData
- ensure clan loading logs error for missing file
- build mission definitions from all JSON files

## Testing
- `pytest Mygames/HCshinobi/tests -q`
- `pytest Mygames/HCshinobi/HCshinobi/tests/core/test_clan_data.py -q`
- `pytest Mygames/HCshinobi/HCshinobi/tests/core/test_mission_system.py::test_get_available_missions -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68458db3fee883298ec80dd894e5eb8b