### PR TITLE
Implement stubs for missing modules

### DIFF
--- a/_discord/extensions.py
+++ b/_discord/extensions.py
@@ -1,8 +1,3 @@
-"""
-Extension modules for the Discord bot integration.
-This package contains cogs and extension modules for Discord bot functionality.
-"""
+"""Extensions for the Discord integration."""
 
-__all__ = [
-    'battle_system'
-]
+__all__ = []

--- a/commands/battle_commands.py
+++ b/commands/battle_commands.py
@@ -1,2 +1,16 @@
-from HCshinobi.core.constants import RarityTier
-from HCshinobi.utils.battle_ui import BattleSystemView 
+"""Placeholder battle commands."""
+
+from discord.ext import commands
+
+class BattleCommands(commands.Cog):
+    """Simple placeholder for battle commands."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.command(name="battle")
+    async def battle(self, ctx: commands.Context) -> None:
+        await ctx.send("Battle system not implemented yet.")
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(BattleCommands(bot))

--- a/commands/character_commands.py
+++ b/commands/character_commands.py
@@ -1,4 +1,17 @@
-from HCshinobi.utils.discord_ui import get_rarity_color
-from HCshinobi.core.constants import RarityTier
-from HCshinobi.utils.embeds import create_character_embed, create_error_embed
-from HCshinobi.core.views import ConfirmView, PaginationView 
+"""Placeholder character commands."""
+
+from discord import app_commands
+from discord.ext import commands
+
+class CharacterCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="create", description="Create a new character")
+    async def create(self, interaction):
+        await interaction.response.send_message(
+            "Character system not implemented yet.", ephemeral=True
+        )
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(CharacterCommands(bot))

--- a/commands/clan_commands.py
+++ b/commands/clan_commands.py
@@ -1,2 +1,17 @@
-from HCshinobi.core.character import Character
-from HCshinobi.utils.embeds import create_clan_embed 
+"""Placeholder clan commands."""
+
+from discord import app_commands
+from discord.ext import commands
+
+class ClanCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="my_clan", description="View your clan info")
+    async def my_clan(self, interaction):
+        await interaction.response.send_message(
+            "Clan system not implemented yet.", ephemeral=True
+        )
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ClanCommands(bot))

--- a/commands/mission_commands.py
+++ b/commands/mission_commands.py
@@ -1,1 +1,17 @@
-from HCshinobi.core.character import Character 
+"""Placeholder mission commands."""
+
+from discord import app_commands
+from discord.ext import commands
+
+class MissionCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="mission_board", description="Show missions")
+    async def mission_board(self, interaction):
+        await interaction.response.send_message(
+            "Mission system not implemented yet.", ephemeral=True
+        )
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(MissionCommands(bot))

--- a/core/battle_system.py
+++ b/core/battle_system.py
@@ -1,1 +1,5 @@
-from HCshinobi.utils.file_io import load_json, save_json 
+"""Placeholder battle system logic."""
+
+class BattleSystem:
+    def start_battle(self, *args, **kwargs):
+        return "Battle started"

--- a/core/character_system.py
+++ b/core/character_system.py
@@ -1,1 +1,25 @@
-from HCshinobi.utils.file_io import load_json, save_json 
+"""Simple in-memory character management."""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+@dataclass
+class Character:
+    user_id: int
+    name: str
+    clan: str
+
+class CharacterSystem:
+    def __init__(self) -> None:
+        self.characters: Dict[int, Character] = {}
+
+    async def create_character(self, user_id: int, name: str, clan: str) -> Character:
+        char = Character(user_id, name, clan)
+        self.characters[user_id] = char
+        return char
+
+    async def get_character(self, user_id: int) -> Optional[Character]:
+        return self.characters.get(user_id)
+
+    async def delete_character(self, user_id: int) -> None:
+        self.characters.pop(user_id, None)

--- a/core/clan_system.py
+++ b/core/clan_system.py
@@ -1,1 +1,5 @@
-from HCshinobi.utils.file_io import load_json, save_json 
+"""Minimal clan system."""
+
+class ClanSystem:
+    def get_clan_info(self, name: str):
+        return {"name": name}

--- a/core/mission_system.py
+++ b/core/mission_system.py
@@ -1,1 +1,5 @@
-from HCshinobi.utils.file_io import load_json, save_json 
+"""Placeholder mission system."""
+
+class MissionSystem:
+    def get_available_missions(self):
+        return []

--- a/utils/battle_ui.py
+++ b/utils/battle_ui.py
@@ -1,1 +1,4 @@
-from HCshinobi.core.character import Character 
+"""Placeholder UI helpers for battles."""
+
+def render_battle_view() -> str:
+    return "[Battle UI Placeholder]"

--- a/utils/discord_ui.py
+++ b/utils/discord_ui.py
@@ -1,1 +1,13 @@
-from HCshinobi.core.constants import RarityTier 
+"""Placeholder Discord UI utilities."""
+
+from discord import Colour
+
+RARITY_COLORS = {
+    "Common": Colour.light_grey(),
+    "Uncommon": Colour.green(),
+    "Rare": Colour.blue(),
+    "Legendary": Colour.gold(),
+}
+
+def get_rarity_color(rarity: str) -> Colour:
+    return RARITY_COLORS.get(rarity, Colour.default())

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -1,1 +1,18 @@
-from HCshinobi.core.clan import Clan 
+"""Utility helpers to create basic embeds."""
+
+import discord
+
+
+def create_error_embed(message: str) -> discord.Embed:
+    embed = discord.Embed(title="Error", description=message, color=discord.Color.red())
+    return embed
+
+
+def create_character_embed(name: str) -> discord.Embed:
+    embed = discord.Embed(title=f"{name}'s Profile")
+    return embed
+
+
+def create_clan_embed(name: str) -> discord.Embed:
+    embed = discord.Embed(title=f"Clan: {name}")
+    return embed


### PR DESCRIPTION
## Summary
- add placeholder implementations for command and system modules
- include simple embed helpers and Discord UI utilities
- update _discord extensions with empty list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'HCshinobi.bot')*

------
https://chatgpt.com/codex/tasks/task_e_6858a27f80008329940a1dc7d1fa3124