### PR TITLE
Implement basic HCShinobi package structure

### DIFF
--- a/HCshinobi/__init__.py
+++ b/HCshinobi/__init__.py
@@ -1,0 +1,1 @@
+"HCShinobi package root"

--- a/HCshinobi/bot/__init__.py
+++ b/HCshinobi/bot/__init__.py
@@ -1,0 +1,3 @@
+from .config import BotConfig
+from .services import ServiceContainer
+from .bot import HCBot

--- a/HCshinobi/bot/bot.py
+++ b/HCshinobi/bot/bot.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+import logging
+import discord
+from discord.ext import commands
+
+from .config import BotConfig
+from .services import ServiceContainer
+
+
+class HCBot(commands.Bot):
+    """Discord bot for HCShinobi."""
+
+    def __init__(self, config: BotConfig, silent_start: bool = False) -> None:
+        intents = discord.Intents.default()
+        super().__init__(command_prefix=config.command_prefix, intents=intents)
+        self.config = config
+        self.services = ServiceContainer(config)
+        self.logger = logging.getLogger("HCShinobi")
+        if not silent_start:
+            self.logger.setLevel(config.log_level)
+
+    async def setup_hook(self) -> None:
+        await self.services.initialize(self)
+
+    async def close(self) -> None:
+        await self.services.shutdown()
+        await super().close()

--- a/HCshinobi/bot/cogs/announcements.py
+++ b/HCshinobi/bot/cogs/announcements.py
@@ -1,0 +1,7 @@
+from discord.ext import commands
+
+class AnnouncementCommands(commands.Cog):
+    """Placeholder announcement commands."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot

--- a/HCshinobi/bot/cogs/battle_system.py
+++ b/HCshinobi/bot/cogs/battle_system.py
@@ -1,0 +1,16 @@
+"""Placeholder battle commands."""
+
+from discord.ext import commands
+
+class BattleSystemCommands(commands.Cog):
+    """Simple placeholder for battle commands."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.command(name="battle")
+    async def battle(self, ctx: commands.Context) -> None:
+        await ctx.send("Battle system not implemented yet.")
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(BattleSystemCommands(bot))

--- a/HCshinobi/bot/cogs/character_commands.py
+++ b/HCshinobi/bot/cogs/character_commands.py
@@ -1,0 +1,17 @@
+"""Placeholder character commands."""
+
+from discord import app_commands
+from discord.ext import commands
+
+class CharacterCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="create", description="Create a new character")
+    async def create(self, interaction):
+        await interaction.response.send_message(
+            "Character system not implemented yet.", ephemeral=True
+        )
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(CharacterCommands(bot))

--- a/HCshinobi/bot/cogs/clan_commands.py
+++ b/HCshinobi/bot/cogs/clan_commands.py
@@ -1,0 +1,17 @@
+"""Placeholder clan commands."""
+
+from discord import app_commands
+from discord.ext import commands
+
+class ClanCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="my_clan", description="View your clan info")
+    async def my_clan(self, interaction):
+        await interaction.response.send_message(
+            "Clan system not implemented yet.", ephemeral=True
+        )
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ClanCommands(bot))

--- a/HCshinobi/bot/cogs/clan_mission_commands.py
+++ b/HCshinobi/bot/cogs/clan_mission_commands.py
@@ -1,0 +1,7 @@
+from discord.ext import commands
+
+class ClanMissionCommands(commands.Cog):
+    """Placeholder clan mission commands."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot

--- a/HCshinobi/bot/cogs/currency.py
+++ b/HCshinobi/bot/cogs/currency.py
@@ -1,0 +1,107 @@
+"""
+Currency commands for HCShinobi.
+Handles currency-related commands like balance, transfer, etc.
+"""
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+from typing import Optional
+
+from HCshinobi.core.character import Character
+from HCshinobi.utils.embeds import create_error_embed
+
+class CurrencyCommands(commands.Cog):
+    """Currency-related commands for HCShinobi."""
+    
+    def __init__(self, bot):
+        self.bot = bot
+    
+    @app_commands.command(name="balance", description="Check your current balance")
+    async def balance(self, interaction: discord.Interaction):
+        """Check the user's current balance."""
+        try:
+            character = Character.load(interaction.user.id)
+            if not character:
+                await interaction.response.send_message(
+                    embed=create_error_embed("You don't have a character yet!"),
+                    ephemeral=True
+                )
+                return
+            
+            embed = discord.Embed(
+                title="Balance",
+                description=f"Your current balance: {character.currency:,} ryo",
+                color=discord.Color.gold()
+            )
+            await interaction.response.send_message(embed=embed)
+            
+        except Exception as e:
+            await interaction.response.send_message(
+                embed=create_error_embed(f"Error checking balance: {str(e)}"),
+                ephemeral=True
+            )
+    
+    @app_commands.command(name="transfer", description="Transfer currency to another user")
+    async def transfer(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+        amount: int
+    ):
+        """Transfer currency to another user."""
+        try:
+            if amount <= 0:
+                await interaction.response.send_message(
+                    embed=create_error_embed("Amount must be positive!"),
+                    ephemeral=True
+                )
+                return
+            
+            sender = Character.load(interaction.user.id)
+            if not sender:
+                await interaction.response.send_message(
+                    embed=create_error_embed("You don't have a character yet!"),
+                    ephemeral=True
+                )
+                return
+            
+            if sender.currency < amount:
+                await interaction.response.send_message(
+                    embed=create_error_embed("You don't have enough currency!"),
+                    ephemeral=True
+                )
+                return
+            
+            recipient = Character.load(user.id)
+            if not recipient:
+                await interaction.response.send_message(
+                    embed=create_error_embed("Recipient doesn't have a character yet!"),
+                    ephemeral=True
+                )
+                return
+            
+            # Perform transfer
+            sender.currency -= amount
+            recipient.currency += amount
+            
+            # Save changes
+            sender.save()
+            recipient.save()
+            
+            embed = discord.Embed(
+                title="Transfer Successful",
+                description=f"Transferred {amount:,} ryo to {user.mention}",
+                color=discord.Color.green()
+            )
+            await interaction.response.send_message(embed=embed)
+            
+        except Exception as e:
+            await interaction.response.send_message(
+                embed=create_error_embed(f"Error transferring currency: {str(e)}"),
+                ephemeral=True
+            )
+
+async def setup(bot):
+    """Set up the currency commands cog."""
+    await bot.add_cog(CurrencyCommands(bot)) 

--- a/HCshinobi/bot/cogs/missions.py
+++ b/HCshinobi/bot/cogs/missions.py
@@ -1,0 +1,17 @@
+"""Placeholder mission commands."""
+
+from discord import app_commands
+from discord.ext import commands
+
+class MissionCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="mission_board", description="Show missions")
+    async def mission_board(self, interaction):
+        await interaction.response.send_message(
+            "Mission system not implemented yet.", ephemeral=True
+        )
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(MissionCommands(bot))

--- a/HCshinobi/bot/cogs/training.py
+++ b/HCshinobi/bot/cogs/training.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from discord.ext import commands
+
+class TrainingIntensity(Enum):
+    LIGHT = "Light"
+    MODERATE = "Moderate"
+    INTENSE = "Intense"
+
+TRAINING_ATTRIBUTES = {
+    "strength": "Strength",
+    "speed": "Speed",
+    "defense": "Defense",
+}
+
+class TrainingView:
+    pass
+
+class TrainingCommands(commands.Cog):
+    """Placeholder training commands."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot

--- a/HCshinobi/bot/config.py
+++ b/HCshinobi/bot/config.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class BotConfig:
+    """Configuration options for HCBot."""
+
+    token: str = ""
+    command_prefix: str = "!"
+    application_id: int = 0
+    guild_id: int = 0
+    battle_channel_id: int = 0
+    online_channel_id: int = 0
+    announcement_channel_id: int = 0
+    equipment_shop_channel_id: int = 0
+    log_level: str = "INFO"
+    data_dir: str = "data"
+    database_url: str = "sqlite:///hcshinobi.db"
+    webhook_url: Optional[str] = None
+    ollama_base_url: Optional[str] = None
+    ollama_model: Optional[str] = None
+    openai_api_key: Optional[str] = None
+    openai_target_url: Optional[str] = None
+    openai_headless: bool = False

--- a/HCshinobi/bot/services.py
+++ b/HCshinobi/bot/services.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from typing import Optional
+from discord.ext import commands
+
+from HCshinobi.core.character_system import CharacterSystem
+from HCshinobi.core.battle_system import BattleSystem
+from HCshinobi.core.clan_system import ClanSystem
+from HCshinobi.core.mission_system import MissionSystem
+
+from .config import BotConfig
+
+
+class ServiceContainer:
+    """Container for all core systems used by the bot."""
+
+    def __init__(self, config: Optional[BotConfig] = None, data_dir: Optional[str] = None) -> None:
+        self.config = config or BotConfig()
+        self.data_dir = data_dir or self.config.data_dir
+
+        self.character_system = CharacterSystem()
+        self.battle_system = BattleSystem()
+        self.clan_system = ClanSystem()
+        self.mission_system = MissionSystem()
+
+        self.currency_system = None
+        self.token_system = None
+        self.training_system = None
+        self.jutsu_shop_system = None
+        self.equipment_shop_system = None
+        self.clan_data = None
+        self.clan_missions = None
+        self.ollama_client = None
+
+        self._initialized = False
+        self.bot: Optional[commands.Bot] = None
+
+    async def initialize(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._initialized = True
+
+    async def shutdown(self) -> None:
+        self._initialized = False
+
+    async def run_ready_hooks(self) -> None:
+        return

--- a/HCshinobi/core/__init__.py
+++ b/HCshinobi/core/__init__.py
@@ -1,0 +1,35 @@
+from .character import Character
+from .character_system import CharacterSystem
+from .battle_system import BattleSystem
+from .clan_system import ClanSystem
+from .mission_system import MissionSystem
+from .currency_system import CurrencySystem
+from .token_system import TokenSystem
+from .training_system import TrainingSystem, TrainingSession
+from .clan_data import ClanData
+from .clan_assignment_engine import ClanAssignmentEngine
+from .progression_engine import ShinobiProgressionEngine
+from .constants import (
+    DATA_DIR,
+    CHARACTERS_SUBDIR,
+    CURRENCY_FILE,
+    TOKEN_FILE,
+    TRAINING_SESSIONS_FILE,
+    TRAINING_COOLDOWNS_FILE,
+    CLANS_SUBDIR,
+)
+
+__all__ = [
+    "Character",
+    "CharacterSystem",
+    "BattleSystem",
+    "ClanSystem",
+    "MissionSystem",
+    "CurrencySystem",
+    "TokenSystem",
+    "TrainingSystem",
+    "TrainingSession",
+    "ClanData",
+    "ClanAssignmentEngine",
+    "ShinobiProgressionEngine",
+]

--- a/HCshinobi/core/battle_system.py
+++ b/HCshinobi/core/battle_system.py
@@ -1,0 +1,5 @@
+"""Placeholder battle system logic."""
+
+class BattleSystem:
+    def start_battle(self, *args, **kwargs):
+        return "Battle started"

--- a/HCshinobi/core/character.py
+++ b/HCshinobi/core/character.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass, field
+from typing import Set
+
+@dataclass
+class Character:
+    """Minimal representation of a player character."""
+
+    id: str
+    name: str
+    clan: str = ""
+    level: int = 1
+    rank: str = "Genin"
+    hp: int = 100
+    max_hp: int = 100
+    chakra: int = 50
+    max_chakra: int = 50
+    stamina: int = 50
+    max_stamina: int = 50
+    strength: int = 10
+    defense: int = 5
+    speed: int = 5
+    ninjutsu: int = 5
+    genjutsu: int = 5
+    taijutsu: int = 5
+    intelligence: int = 5
+    willpower: int = 5
+    chakra_control: int = 5
+    xp: int = 0
+
+    completed_missions: Set[str] = field(default_factory=set)
+    achievements: Set[str] = field(default_factory=set)

--- a/HCshinobi/core/character_system.py
+++ b/HCshinobi/core/character_system.py
@@ -1,0 +1,25 @@
+"""Simple in-memory character management."""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+@dataclass
+class Character:
+    user_id: int
+    name: str
+    clan: str
+
+class CharacterSystem:
+    def __init__(self) -> None:
+        self.characters: Dict[int, Character] = {}
+
+    async def create_character(self, user_id: int, name: str, clan: str) -> Character:
+        char = Character(user_id, name, clan)
+        self.characters[user_id] = char
+        return char
+
+    async def get_character(self, user_id: int) -> Optional[Character]:
+        return self.characters.get(user_id)
+
+    async def delete_character(self, user_id: int) -> None:
+        self.characters.pop(user_id, None)

--- a/HCshinobi/core/clan_assignment_engine.py
+++ b/HCshinobi/core/clan_assignment_engine.py
@@ -1,0 +1,8 @@
+class ClanAssignmentEngine:
+    """Placeholder clan assignment logic."""
+
+    def assign_clan(self, player_id: str, player_name: str, **kwargs):
+        return {"assigned_clan": "None", "clan_rarity": "Common"}
+
+    def get_player_clan(self, player_id: str):
+        return None

--- a/HCshinobi/core/clan_data.py
+++ b/HCshinobi/core/clan_data.py
@@ -1,0 +1,14 @@
+class ClanData:
+    """Placeholder clan data access."""
+
+    def __init__(self, data_dir: str = "") -> None:
+        self.data_dir = data_dir
+
+    def get_all_clans(self):
+        return []
+
+    async def get_clan_by_name(self, name: str):
+        return None
+
+    def create_default_clans(self):
+        return {}

--- a/HCshinobi/core/clan_system.py
+++ b/HCshinobi/core/clan_system.py
@@ -1,0 +1,5 @@
+"""Minimal clan system."""
+
+class ClanSystem:
+    def get_clan_info(self, name: str):
+        return {"name": name}

--- a/HCshinobi/core/constants.py
+++ b/HCshinobi/core/constants.py
@@ -1,0 +1,7 @@
+DATA_DIR = "data"
+CHARACTERS_SUBDIR = "characters"
+CURRENCY_FILE = "currency.json"
+TOKEN_FILE = "tokens.json"
+TRAINING_SESSIONS_FILE = "training_sessions.json"
+TRAINING_COOLDOWNS_FILE = "training_cooldowns.json"
+CLANS_SUBDIR = "clans"

--- a/HCshinobi/core/currency_system.py
+++ b/HCshinobi/core/currency_system.py
@@ -1,0 +1,14 @@
+class CurrencySystem:
+    """Simple in-memory currency manager."""
+
+    def __init__(self, data_path: str = "") -> None:
+        self.balances = {}
+
+    async def get_player_balance(self, user_id: str) -> int:
+        return self.balances.get(user_id, 0)
+
+    async def set_player_balance(self, user_id: str, amount: int) -> None:
+        self.balances[user_id] = amount
+
+    def add_balance_and_save(self, user_id: str, amount: int) -> None:
+        self.balances[user_id] = self.balances.get(user_id, 0) + amount

--- a/HCshinobi/core/mission_system.py
+++ b/HCshinobi/core/mission_system.py
@@ -1,0 +1,5 @@
+"""Placeholder mission system."""
+
+class MissionSystem:
+    def get_available_missions(self):
+        return []

--- a/HCshinobi/core/progression_engine.py
+++ b/HCshinobi/core/progression_engine.py
@@ -1,0 +1,5 @@
+class ShinobiProgressionEngine:
+    """Placeholder progression engine."""
+
+    def get_level_up_requirements(self, level: int) -> int:
+        return 0

--- a/HCshinobi/core/token_system.py
+++ b/HCshinobi/core/token_system.py
@@ -1,0 +1,11 @@
+class TokenSystem:
+    """Simple token tracking system."""
+
+    def __init__(self, data_path: str = "") -> None:
+        self.tokens = {}
+
+    async def get_player_tokens(self, user_id: str) -> int:
+        return self.tokens.get(user_id, 0)
+
+    async def add_tokens(self, user_id: str, amount: int) -> None:
+        self.tokens[user_id] = self.tokens.get(user_id, 0) + amount

--- a/HCshinobi/core/training_system.py
+++ b/HCshinobi/core/training_system.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+@dataclass
+class TrainingSession:
+    user_id: str
+    attribute: str
+    intensity: str
+
+class TrainingSystem:
+    """Very small placeholder training system."""
+
+    def __init__(self) -> None:
+        self.active_sessions: Dict[str, TrainingSession] = {}
+        self.cooldowns: Dict[str, int] = {}
+
+    def get_training_status(self, user_id: str) -> Optional[TrainingSession]:
+        return self.active_sessions.get(user_id)
+
+    def get_training_status_embed(self, user_id: str):
+        return None

--- a/HCshinobi/utils/battle_ui.py
+++ b/HCshinobi/utils/battle_ui.py
@@ -1,0 +1,4 @@
+"""Placeholder UI helpers for battles."""
+
+def render_battle_view() -> str:
+    return "[Battle UI Placeholder]"

--- a/HCshinobi/utils/discord_ui.py
+++ b/HCshinobi/utils/discord_ui.py
@@ -1,0 +1,13 @@
+"""Placeholder Discord UI utilities."""
+
+from discord import Colour
+
+RARITY_COLORS = {
+    "Common": Colour.light_grey(),
+    "Uncommon": Colour.green(),
+    "Rare": Colour.blue(),
+    "Legendary": Colour.gold(),
+}
+
+def get_rarity_color(rarity: str) -> Colour:
+    return RARITY_COLORS.get(rarity, Colour.default())

--- a/HCshinobi/utils/embeds.py
+++ b/HCshinobi/utils/embeds.py
@@ -1,0 +1,18 @@
+"""Utility helpers to create basic embeds."""
+
+import discord
+
+
+def create_error_embed(message: str) -> discord.Embed:
+    embed = discord.Embed(title="Error", description=message, color=discord.Color.red())
+    return embed
+
+
+def create_character_embed(name: str) -> discord.Embed:
+    embed = discord.Embed(title=f"{name}'s Profile")
+    return embed
+
+
+def create_clan_embed(name: str) -> discord.Embed:
+    embed = discord.Embed(title=f"Clan: {name}")
+    return embed

--- a/run.py
+++ b/run.py
@@ -41,14 +41,14 @@ async def main():
     # Load cogs after bot is instantiated
     from HCshinobi.bot.cogs.character_commands import CharacterCommands
     from HCshinobi.bot.cogs.currency import CurrencyCommands
-    from HCshinobi.bot.cogs.battle_system import BattleCommands
+    from HCshinobi.bot.cogs.battle_system import BattleSystemCommands
     from HCshinobi.bot.cogs.missions import MissionCommands
-    from HCshinobi.bot.cogs.clan_commands import ClanMissionCommands
+    from HCshinobi.bot.cogs.clan_mission_commands import ClanMissionCommands
     
     # Add cogs to bot
     await bot.add_cog(CharacterCommands(bot))
     await bot.add_cog(CurrencyCommands(bot))
-    await bot.add_cog(BattleCommands(bot))
+    await bot.add_cog(BattleSystemCommands(bot))
     await bot.add_cog(MissionCommands(bot))
     await bot.add_cog(ClanMissionCommands(bot))
     


### PR DESCRIPTION
## Summary
- create `HCshinobi` package with core, bot and utils subpackages
- implement `BotConfig`, `ServiceContainer` and `HCBot`
- add placeholder cog modules
- update `run.py` to use the new package

## Testing
- `pip install -r requirements-test.txt`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'HCshinobi.core.personality_modifiers')*

------
https://chatgpt.com/codex/tasks/task_e_685d3de8a74c83299a0ccc60790fed25