### PR TITLE
Implement mission rewards and sprint update

### DIFF
--- a/bot/services.py
+++ b/bot/services.py
@@ -24,10 +24,14 @@ class ServiceContainer:
         self.clan_assignment_engine = ClanAssignmentEngine(self.clan_system)
         self.currency_system = CurrencySystem(data_dir)
         self.token_system = TokenSystem(data_dir)
-        self.mission_system = MissionSystem(data_dir)
+        self.progression_engine = ShinobiProgressionEngine()
+        self.mission_system = MissionSystem(
+            data_dir,
+            currency_system=self.currency_system,
+            progression_engine=self.progression_engine,
+        )
         self.training_system = TrainingSystem(data_dir)
         self.battle_persistence = BattlePersistence(data_dir)
-        self.progression_engine = ShinobiProgressionEngine()
         self.battle_lifecycle = BattleLifecycle(self.character_system, self.battle_persistence, self.progression_engine)
 
     async def initialize(self, bot=None) -> None:

--- a/core/mission_system.py
+++ b/core/mission_system.py
@@ -3,16 +3,26 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
+
+from .currency_system import CurrencySystem
+from .progression_engine import ShinobiProgressionEngine
 
 
 class MissionSystem:
-    def __init__(self, data_dir: str = "data") -> None:
+    def __init__(
+        self,
+        data_dir: str = "data",
+        currency_system: Optional[CurrencySystem] = None,
+        progression_engine: Optional[ShinobiProgressionEngine] = None,
+    ) -> None:
         self.data_dir = Path(data_dir) / "missions"
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.def_file = self.data_dir / "mission_definitions.json"
         self.active_file = self.data_dir / "active_missions.json"
         self.completed_file = self.data_dir / "completed_missions.json"
+        self.currency_system = currency_system
+        self.progression_engine = progression_engine
         self._load_definitions()
         self.active: Dict[str, Dict] = {}
         self.completed: Dict[str, List[Dict]] = {}
@@ -41,4 +51,17 @@ class MissionSystem:
         if not mission:
             return False, "No active mission", {}
         self.completed.setdefault(player_id, []).append(mission)
-        return True, "Mission completed successfully", {"exp": mission.get("reward_exp", 0), "ryo": mission.get("reward_ryo", 0), "items": []}
+
+        rewards = {
+            "exp": mission.get("reward_exp", 0),
+            "ryo": mission.get("reward_ryo", 0),
+            "items": []
+        }
+
+        if self.currency_system and rewards["ryo"]:
+            self.currency_system.add_balance_and_save(player_id, rewards["ryo"])
+
+        if self.progression_engine and rewards["exp"]:
+            await self.progression_engine.award_mission_experience(player_id, rewards["exp"])
+
+        return True, "Mission completed successfully", rewards

--- a/core/progression_engine.py
+++ b/core/progression_engine.py
@@ -6,3 +6,7 @@ class ShinobiProgressionEngine:
     async def award_battle_experience(self, player_id: str, exp: int) -> None:
         # In a real implementation this would update the character.
         return None
+
+    async def award_mission_experience(self, player_id: str, exp: int) -> None:
+        """Award experience for completing missions."""
+        return None

--- a/docs/sprint_tasks.md
+++ b/docs/sprint_tasks.md
@@ -1,18 +1,22 @@
 # Sprint Task List
 
-## Date: 2025-04-08
+## Date: 2025-06-27
 
 ### High Priority
-- Implement basic character creation storage
-- Finish clan assignment logic with personality modifiers
-- Add token spend/reroll functionality
-- Create unit tests for character and clan systems
+- Character creation & profile viewing
+- Clan assignment with token rerolls
+- Currency and token tracking commands
+- Training system with timed sessions
+- Mission board listing missions and awarding currency
+- Structured logging and environment verification (`verify_beta.py`)
 
 ### Medium Priority
-- Prototype mission board command with placeholder missions
-- Wire up training system start/cancel commands
-- Flesh out battle system data structures
+- Turn-based battle flow with persistence and EXP rewards
+- Jutsu and equipment shops
+- NPC conversion for fallen players
+- AI-generated mission narratives
 
 ### Low Priority
-- Add initial logging configuration
-- Update documentation for new commands
+- Clan-specific bonuses and abilities
+- Web dashboard research
+- Additional documentation and test coverage (>90%)

--- a/tests/core/test_mission_system_rewards.py
+++ b/tests/core/test_mission_system_rewards.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from HCshinobi.core.mission_system import MissionSystem
+from HCshinobi.core.currency_system import CurrencySystem
+from HCshinobi.core.progression_engine import ShinobiProgressionEngine
+
+@pytest.mark.asyncio
+async def test_complete_mission_awards_rewards(tmp_path):
+    currency = MagicMock(spec=CurrencySystem)
+    progression = AsyncMock(spec=ShinobiProgressionEngine)
+
+    data_dir = tmp_path
+    missions = MissionSystem(str(data_dir), currency_system=currency, progression_engine=progression)
+    missions.definitions = [
+        {"mission_id": "m1", "title": "Test", "reward_ryo": 10, "reward_exp": 5}
+    ]
+
+    await missions.assign_mission("user", "m1")
+    success, msg, rewards = await missions.complete_mission("user")
+
+    assert success
+    assert rewards["ryo"] == 10
+    assert rewards["exp"] == 5
+    currency.add_balance_and_save.assert_called_once_with("user", 10)
+    progression.award_mission_experience.assert_awaited_once_with("user", 5)


### PR DESCRIPTION
## Summary
- wire MissionSystem rewards into currency and progression systems
- expose reward handling via ServiceContainer
- note new mission reward test in `tests/core`
- update sprint plan for beta goals

## Testing
- `pytest tests/core/test_mission_system_rewards.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'HCshinobi.bot.cogs.clans')*

------
https://chatgpt.com/codex/tasks/task_e_685ec81be7108329a180cbdcb745b690