### PR TITLE
Implement basic clan, training, and mission modules

### DIFF
--- a/bot/cogs/announcements.py
+++ b/bot/cogs/announcements.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+from datetime import datetime
+
+class AnnouncementCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="announce")
+    async def announce(self, interaction: discord.Interaction, title: str, message: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        if not message:
+            await interaction.followup.send(content="Announcement message cannot be empty")
+            return
+        await interaction.followup.send(content="Announcement sent")
+
+    @app_commands.command(name="battle_announce")
+    async def battle_announce(self, interaction: discord.Interaction, fighter_a: str, fighter_b: str, arena: str, time: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(content="Battle announcement sent")
+
+    @app_commands.command(name="lore_drop")
+    async def lore_drop(self, interaction: discord.Interaction, title: str, snippet: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(content="Lore drop sent")
+
+    @app_commands.command(name="check_permissions")
+    async def check_permissions(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(embed=discord.Embed(title="Permissions"))
+
+    @app_commands.command(name="check_bot_role")
+    async def check_bot_role(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(embed=discord.Embed(title="Bot Role"))
+
+    @app_commands.command(name="send_system_alert")
+    async def send_system_alert(self, interaction: discord.Interaction, title: str, message: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(content="Alert sent")
+
+    @app_commands.command(name="broadcast_lore")
+    async def broadcast_lore(self, interaction: discord.Interaction, trigger: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(content="Broadcasting lore")
+
+    @app_commands.command(name="alert_clan")
+    async def alert_clan(self, interaction: discord.Interaction, clan_name: str, title: str, message: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(content=f"Alerted {clan_name}")
+
+    @app_commands.command(name="view_lore")
+    async def view_lore(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(content="Lore view")
+
+    @app_commands.command(name="update")
+    async def update(self, interaction: discord.Interaction, version: str, release_date: str, changes: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        try:
+            datetime.fromisoformat(release_date)
+        except ValueError:
+            await interaction.followup.send(content=f"Invalid date format: {release_date}")
+            return
+        await interaction.followup.send(content="Update recorded")

--- a/bot/cogs/clan_commands.py
+++ b/bot/cogs/clan_commands.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+class ClanCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="view_clan")
+    async def view_clan(self, interaction: discord.Interaction, name: str) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.followup.send("This command is not implemented yet.")
+
+    @app_commands.command(name="create_clan")
+    async def create_clan(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.followup.send("This command is not implemented yet.")
+
+    @app_commands.command(name="join_clan")
+    async def join_clan(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.followup.send("This command is not implemented yet.")
+
+    @app_commands.command(name="leave_clan")
+    async def leave_clan(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.followup.send("This command is not implemented yet.")
+
+    @app_commands.command(name="clan_members")
+    async def clan_members(self, interaction: discord.Interaction, clan_name: str) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.followup.send("This command is not implemented yet.")
+
+    @app_commands.command(name="clan_leaderboard")
+    async def clan_leaderboard(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.followup.send("This command is not implemented yet.")
+
+    @app_commands.command(name="my_clan")
+    async def my_clan(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.followup.send("This command is not implemented yet.")

--- a/bot/cogs/clans.py
+++ b/bot/cogs/clans.py
@@ -6,6 +6,24 @@ from discord import app_commands
 from discord.ext import commands
 
 from HCshinobi.core.clan_data import ClanData
+from enum import Enum
+
+class RarityTier(Enum):
+    COMMON = "Common"
+    UNCOMMON = "Uncommon"
+    RARE = "Rare"
+    LEGENDARY = "Legendary"
+    EPIC = "Epic"
+
+def get_rarity_color(rarity: str) -> discord.Color:
+    mapping = {
+        RarityTier.COMMON.value: discord.Color.light_grey(),
+        RarityTier.UNCOMMON.value: discord.Color.green(),
+        RarityTier.RARE.value: discord.Color.purple(),
+        RarityTier.LEGENDARY.value: discord.Color.gold(),
+        RarityTier.EPIC.value: discord.Color.red(),
+    }
+    return mapping.get(rarity, discord.Color.default())
 
 
 class ClanCommands(commands.Cog):
@@ -14,19 +32,82 @@ class ClanCommands(commands.Cog):
 
     @app_commands.command(name="clan_list", description="List clans")
     async def clan_list(self, interaction: discord.Interaction) -> None:
-        clans = await self.bot.services.clan_system.list_clans()
+        clans = await self.bot.services.clan_data.get_all_clans()
         embed = discord.Embed(title="Available Clans")
+        if not clans:
+            embed.description = "No clans have been loaded"
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+            return
+        by_rarity: dict[str, list[str]] = {}
         for clan in clans:
-            embed.add_field(name=clan["name"], value=clan.get("rarity", ""), inline=False)
+            by_rarity.setdefault(clan.get("rarity", RarityTier.COMMON.value), []).append(clan["name"])
+        for rarity, names in sorted(by_rarity.items(), key=lambda i: i[0]):
+            names.sort()
+            embed.add_field(name=f"🏅 {rarity}", value="- " + "\n- ".join(names), inline=False)
         await interaction.response.send_message(embed=embed)
 
     @app_commands.command(name="my_clan", description="My clan")
     async def my_clan(self, interaction: discord.Interaction) -> None:
-        clan = None
-        embed = discord.Embed(title="Your Clan Assignment")
-        if clan:
-            embed.description = f"You belong to the **{clan}** clan."
-        else:
+        user_id = interaction.user.id
+        clan_name = self.bot.services.clan_assignment_engine.get_player_clan(user_id)
+        if not clan_name:
             await interaction.response.send_message("You have not been assigned a clan yet. Use `/roll_clan` to get started!", ephemeral=True)
             return
+        details = await self.bot.services.clan_data.get_clan_by_name(clan_name)
+        color = get_rarity_color(details.get("rarity", ""))
+        embed = discord.Embed(title="Your Clan Assignment", description=f"You belong to the **{clan_name}** clan.", color=color)
         await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @app_commands.command(name="clan_info", description="Get clan info")
+    async def clan_info(self, interaction: discord.Interaction, clan_name: str) -> None:
+        details = await self.bot.services.clan_data.get_clan_by_name(clan_name)
+        if not details:
+            all_clans = await self.bot.services.clan_data.get_all_clans()
+            suggestions = [c["name"] for c in all_clans if clan_name.lower() in c["name"].lower()]
+            suggestion_text = "\n".join(suggestions)
+            await interaction.response.send_message(
+                f"Clan '{clan_name}' not found. Did you mean one of these?\n{suggestion_text}",
+                ephemeral=True,
+            )
+            return
+        color = get_rarity_color(details.get("rarity", ""))
+        embed = discord.Embed(title=f"{details['name']} Clan", description=details.get("description", ""), color=color)
+        embed.add_field(name="Rarity", value=details.get("rarity", ""))
+        embed.add_field(name="Members", value=str(len(details.get("members", []))))
+        await interaction.response.send_message(embed=embed)
+
+    @app_commands.command(name="create_clan", description="Create a clan")
+    async def create_clan(self, interaction: discord.Interaction, name: str, description: str, rarity: str) -> None:
+        if not interaction.user.guild_permissions.administrator:
+            await interaction.response.send_message("You need administrator permissions to create clans.", ephemeral=True)
+            return
+        clan = {"name": name, "description": description, "rarity": rarity, "members": []}
+        await self.bot.services.clan_data.add_clan(clan)
+        await interaction.response.send_message(f"Successfully created clan {name}", ephemeral=True)
+
+    @app_commands.command(name="join_clan", description="Join a clan")
+    async def join_clan(self, interaction: discord.Interaction, clan_name: str) -> None:
+        details = await self.bot.services.clan_data.get_clan_by_name(clan_name)
+        if not details:
+            await interaction.response.send_message(f"Clan '{clan_name}' not found. Use `/clan_list` to see available clans.", ephemeral=True)
+            return
+        user_id = interaction.user.id
+        if user_id in details.get("members", []):
+            await interaction.response.send_message("You are already a member of this clan.", ephemeral=True)
+            return
+        details.setdefault("members", []).append(user_id)
+        await self.bot.services.clan_data.update_clan(details)
+        await interaction.response.send_message(f"Successfully joined clan {clan_name}", ephemeral=True)
+
+    @app_commands.command(name="clan", description="View your current clan")
+    async def clan(self, interaction: discord.Interaction) -> None:
+        user_id = interaction.user.id
+        details = await self.bot.services.clan_data.get_clan_by_member(str(user_id))
+        if not details:
+            await interaction.response.send_message("You are not currently in a clan. Use `/clan_list` to see available clans.", ephemeral=True)
+            return
+        color = get_rarity_color(details.get("rarity", ""))
+        embed = discord.Embed(title=f"{details['name']} Clan", description=details.get("description", ""), color=color)
+        embed.add_field(name="Rarity", value=details.get("rarity", ""))
+        embed.add_field(name="Members", value=str(len(details.get("members", []))))
+        await interaction.response.send_message(embed=embed)

--- a/bot/cogs/currency.py
+++ b/bot/cogs/currency.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+class CurrencyCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="balance", description="Check your balance")
+    async def balance(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send("Currency system not implemented yet.")

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+class HelpCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.support_url: str | None = None
+
+    @app_commands.command(name="help", description="Show help information")
+    async def help(self, interaction: discord.Interaction, command_or_category: str | None = None) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send("Help command placeholder", ephemeral=True)

--- a/bot/cogs/room.py
+++ b/bot/cogs/room.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+class RoomCommands(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="look")
+    async def look(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(embed=discord.Embed(title="Room"), ephemeral=True)
+
+    @app_commands.command(name="move")
+    async def move(self, interaction: discord.Interaction, direction: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(embed=discord.Embed(title="Moved"), ephemeral=True)
+
+    @app_commands.command(name="enter")
+    async def enter(self, interaction: discord.Interaction, room_id: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(embed=discord.Embed(title="Entered"), ephemeral=True)
+
+    @app_commands.command(name="room_info")
+    async def room_info(self, interaction: discord.Interaction, room_id: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(embed=discord.Embed(title="Room Info"), ephemeral=True)
+
+    @app_commands.command(name="room_enter")
+    async def room_enter(self, interaction: discord.Interaction, room_id: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(embed=discord.Embed(title="Entered Room"), ephemeral=True)
+
+    @app_commands.command(name="room_leave")
+    async def room_leave(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(embed=discord.Embed(title="Left Room"), ephemeral=True)

--- a/bot/cogs/training.py
+++ b/bot/cogs/training.py
@@ -7,6 +7,13 @@ from discord.ext import commands
 
 from HCshinobi.core.training_system import TrainingIntensity
 
+# Simple mapping of attributes that can be trained
+TRAINING_ATTRIBUTES = {
+    "taijutsu": "Hand-to-hand combat",
+    "ninjutsu": "Chakra techniques",
+    "genjutsu": "Illusion arts",
+}
+
 
 class TrainingView(discord.ui.View):
     def __init__(self, character) -> None:
@@ -27,6 +34,9 @@ class TrainingCommands(commands.Cog):
         char = await self.bot.services.character_system.get_character(interaction.user.id)
         if not char:
             await interaction.followup.send("You must create a character first using `/create`.", ephemeral=True)
+            return
+        if self.bot.services.training_system.get_training_status(interaction.user.id):
+            await interaction.followup.send("You are already training.", ephemeral=True)
             return
         view = TrainingView(char)
         embed = discord.Embed(title="🎯 Training Setup")

--- a/core/missions/__init__.py
+++ b/core/missions/__init__.py
@@ -1,0 +1,5 @@
+from .mission import Mission, MissionStatus, MissionDifficulty
+from .discord_interface import MissionInterface
+from .generator import MissionGenerator
+
+__all__ = ["Mission", "MissionStatus", "MissionDifficulty", "MissionInterface", "MissionGenerator"]

--- a/core/missions/discord_interface.py
+++ b/core/missions/discord_interface.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from . import Mission, MissionDifficulty, MissionStatus
+from .generator import MissionGenerator
+
+class MissionInterface(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.active_missions: Dict[str, List[Mission]] = {}
+        self.player_missions: Dict[int, Mission] = {}
+        self._village_cooldowns: Dict[str, datetime] = {}
+
+    async def _generate_mission(self, village: str, difficulty: str) -> Mission:
+        async with MissionGenerator() as gen:
+            missions = await gen.generate_mission_batch(village, [MissionDifficulty(difficulty)], 1)
+            return missions[0]
+
+    @app_commands.command(name="mission")
+    async def mission_command(self, interaction: discord.Interaction, difficulty: str, village: str) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        now = datetime.now(timezone.utc)
+        last = self._village_cooldowns.get(village)
+        if last and (now - last).total_seconds() < 2:
+            await interaction.followup.send("Please wait before requesting another mission.", ephemeral=True)
+            return
+        mission = await self._generate_mission(village, difficulty)
+        self.active_missions.setdefault(village, []).append(mission)
+        self.player_missions[interaction.user.id] = mission
+        self._village_cooldowns[village] = now
+        await interaction.followup.send(f"Mission '{mission.title}' created", ephemeral=True)
+
+    @app_commands.command(name="missions")
+    async def missions_command(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        mission = self.player_missions.get(interaction.user.id)
+        if mission and mission.check_expired():
+            await interaction.followup.send("Your mission has expired.", ephemeral=True)
+            return
+        if not mission:
+            await interaction.followup.send("No active mission.", ephemeral=True)
+            return
+        embed = discord.Embed(title="Active Mission", description=mission.title)
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @app_commands.command(name="complete_mission")
+    async def complete_mission_command(self, interaction: discord.Interaction, mission_id: str) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        mission = self.player_missions.get(interaction.user.id)
+        if not mission or mission.id != mission_id:
+            await interaction.followup.send("Mission not found", ephemeral=True)
+            return
+        if mission.check_expired():
+            await interaction.followup.send("Mission expired", ephemeral=True)
+            return
+        if mission.status == MissionStatus.COMPLETED:
+            await interaction.followup.send("Mission already completed", ephemeral=True)
+            return
+        mission.complete()
+        await interaction.followup.send("Mission completed", ephemeral=True)

--- a/core/missions/generator.py
+++ b/core/missions/generator.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import aiohttp
+import json
+import uuid
+from typing import List
+from datetime import timedelta
+
+from . import Mission, MissionDifficulty
+
+class MissionGenerator:
+    def __init__(self) -> None:
+        self.session: aiohttp.ClientSession | None = None
+
+    async def __aenter__(self):
+        self.session = aiohttp.ClientSession()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if self.session:
+            await self.session.close()
+
+    async def generate_mission(self, village: str, difficulty: MissionDifficulty) -> Mission:
+        payload = {"village": village, "difficulty": difficulty.value}
+        assert self.session is not None
+        async with self.session.post("http://localhost", json=payload) as resp:
+            data = await resp.json()
+        details = json.loads(data.get("response", "{}"))
+        return Mission(
+            id=str(uuid.uuid4()),
+            title=details.get("title", "Mission"),
+            description=details.get("description", ""),
+            difficulty=difficulty,
+            village=village,
+            reward=details.get("reward", {}),
+            duration=timedelta(hours=details.get("duration_hours", 1)),
+            requirements=details.get("requirements", {}),
+        )
+
+    async def generate_mission_batch(
+        self, village: str, difficulties: List[MissionDifficulty], count: int
+    ) -> List[Mission]:
+        missions: List[Mission] = []
+        for diff in difficulties:
+            for _ in range(count):
+                missions.append(await self.generate_mission(village, diff))
+        return missions

--- a/core/missions/mission.py
+++ b/core/missions/mission.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Dict, Any
+
+class MissionStatus(Enum):
+    AVAILABLE = "available"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    EXPIRED = "expired"
+
+class MissionDifficulty(Enum):
+    D_RANK = "D"
+    C_RANK = "C"
+    B_RANK = "B"
+    A_RANK = "A"
+    S_RANK = "S"
+
+@dataclass
+class Mission:
+    id: str
+    title: str
+    description: str
+    difficulty: MissionDifficulty
+    village: str
+    reward: Dict[str, Any]
+    duration: timedelta
+    requirements: Dict[str, Any] | None = None
+    status: MissionStatus = MissionStatus.AVAILABLE
+    progress: Dict[str, Any] = field(default_factory=dict)
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    def start(self) -> None:
+        if self.status != MissionStatus.AVAILABLE:
+            raise ValueError("Mission cannot be started")
+        self.status = MissionStatus.IN_PROGRESS
+        self.started_at = datetime.now(timezone.utc)
+
+    def complete(self) -> None:
+        if self.status != MissionStatus.IN_PROGRESS:
+            raise ValueError("Mission cannot be completed")
+        self.status = MissionStatus.COMPLETED
+        self.completed_at = datetime.now(timezone.utc)
+
+    def fail(self) -> None:
+        if self.status not in (MissionStatus.IN_PROGRESS, MissionStatus.AVAILABLE):
+            raise ValueError("Mission cannot be failed")
+        self.status = MissionStatus.FAILED
+
+    def check_expired(self) -> bool:
+        if not self.started_at:
+            return False
+        if datetime.now(timezone.utc) >= self.started_at + self.duration:
+            self.status = MissionStatus.EXPIRED
+            return True
+        return False
+
+    def update_progress(self, key: str, value: Any) -> None:
+        if self.status != MissionStatus.IN_PROGRESS:
+            raise ValueError("Mission not active")
+        self.progress[key] = value
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "difficulty": self.difficulty.value,
+            "village": self.village,
+            "reward": self.reward,
+            "duration_seconds": int(self.duration.total_seconds()),
+            "requirements": self.requirements or {},
+            "status": self.status.value,
+            "progress": self.progress,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Mission":
+        mission = cls(
+            id=data["id"],
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            difficulty=MissionDifficulty(data.get("difficulty", "D")),
+            village=data.get("village", ""),
+            reward=data.get("reward", {}),
+            duration=timedelta(seconds=data.get("duration_seconds", 0)),
+            requirements=data.get("requirements", {}),
+        )
+        mission.status = MissionStatus(data.get("status", MissionStatus.AVAILABLE.value))
+        mission.progress = data.get("progress", {})
+        if data.get("started_at"):
+            mission.started_at = datetime.fromisoformat(data["started_at"])
+        if data.get("completed_at"):
+            mission.completed_at = datetime.fromisoformat(data["completed_at"])
+        return mission


### PR DESCRIPTION
## Summary
- implement Mission model and generator
- add MissionInterface cog
- add placeholder cogs: announcements, currency, help, room, clan_commands
- flesh out clan cog with rarity tiers
- update training cog with attribute constants

## Testing
- `python -m py_compile core/missions/*.py bot/cogs/*.py`
- `pytest tests/cogs/test_training.py::TestTrainingCommands::test_train_command_sends_view -q`
- `pytest tests/cogs/test_clans.py::TestClanCommands::test_clan_list_success -q`


------
https://chatgpt.com/codex/tasks/task_e_686115fb7b6c83298264c211fc2ca52a