### PR TITLE
Enhance training system with currency costs

### DIFF
--- a/HCshinobi/bot/services.py
+++ b/HCshinobi/bot/services.py
@@ -21,7 +21,10 @@ class ServiceContainer:
         self.character_system = CharacterSystem()
         self.currency_system = CurrencySystem()
         self.token_system = TokenSystem()
-        self.training_system = TrainingSystem()
+        self.training_system = TrainingSystem(
+            currency_system=self.currency_system,
+            character_system=self.character_system,
+        )
         self.clan_assignment_engine = ClanAssignmentEngine()
         self.progression_engine = ShinobiProgressionEngine()
         self.clan_data = ClanData(self.data_dir)

--- a/HCshinobi/core/training_system.py
+++ b/HCshinobi/core/training_system.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
+
+from .currency_system import CurrencySystem
+from .character_system import CharacterSystem
 
 
 class TrainingIntensity:
@@ -32,11 +35,20 @@ class TrainingSession:
 
 
 class TrainingSystem:
-    def __init__(self, data_dir: str = "data") -> None:
+    COOLDOWN_HOURS = 1
+
+    def __init__(
+        self,
+        data_dir: str = "data",
+        currency_system: Optional[CurrencySystem] = None,
+        character_system: Optional[CharacterSystem] = None,
+    ) -> None:
         self.data_dir = Path(data_dir) / "training"
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.active_sessions: Dict[str, TrainingSession] = {}
         self.cooldowns: Dict[str, datetime] = {}
+        self.currency_system = currency_system
+        self.character_system = character_system
 
     def _get_training_cost(self, attribute: str) -> int:
         return 10
@@ -51,6 +63,19 @@ class TrainingSystem:
         user_id = str(user_id)
         if user_id in self.active_sessions:
             return False, "Already training"
+        cd_until = self.cooldowns.get(user_id)
+        if cd_until and datetime.now(timezone.utc) < cd_until:
+            remaining = cd_until - datetime.now(timezone.utc)
+            hrs = int(remaining.total_seconds() // 3600) + 1
+            return False, f"On cooldown for {hrs}h"
+        base_cost = self._get_training_cost(attribute)
+        multiplier, _ = TrainingIntensity.get_multipliers(intensity)
+        cost = int(base_cost * duration_hours * multiplier)
+        if self.currency_system:
+            balance = await self.currency_system.get_player_balance(user_id)
+            if balance < cost:
+                return False, f"Insufficient Ryō! Cost: {cost}"
+            await self.currency_system.add_balance(user_id, -cost)
         self.active_sessions[user_id] = TrainingSession(
             user_id,
             attribute,
@@ -86,4 +111,25 @@ class TrainingSystem:
             return False, "No active training"
         self.active_sessions.pop(uid)
         return True, "Training cancelled"
+
+    async def complete_training(self, user_id: int | str, force_complete: bool = False) -> Tuple[bool, str, float]:
+        uid = str(user_id)
+        session = self.active_sessions.get(uid)
+        if not session:
+            return False, "No active training", 0.0
+        elapsed = datetime.now(timezone.utc) - session.start_time
+        if not force_complete and elapsed < timedelta(hours=session.duration_hours):
+            return False, "Training still in progress", 0.0
+        self.active_sessions.pop(uid)
+        stat_mult, _ = TrainingIntensity.get_multipliers(session.intensity)
+        gain = session.duration_hours * stat_mult
+        if self.character_system:
+            char = await self.character_system.get_character(uid)
+            if char:
+                current = getattr(char, session.attribute, 0)
+                setattr(char, session.attribute, current + gain)
+                await self.character_system.save_character(char)
+        self.cooldowns[uid] = datetime.now(timezone.utc) + timedelta(hours=self.COOLDOWN_HOURS)
+        return True, f"Training completed! Points Gained: **{gain:.2f}**", gain
+
 

--- a/bot/services.py
+++ b/bot/services.py
@@ -30,7 +30,11 @@ class ServiceContainer:
             currency_system=self.currency_system,
             progression_engine=self.progression_engine,
         )
-        self.training_system = TrainingSystem(data_dir)
+        self.training_system = TrainingSystem(
+            data_dir,
+            currency_system=self.currency_system,
+            character_system=self.character_system,
+        )
         self.battle_persistence = BattlePersistence(data_dir)
         self.battle_lifecycle = BattleLifecycle(self.character_system, self.battle_persistence, self.progression_engine)
 


### PR DESCRIPTION
## Summary
- integrate currency and character systems into the training system
- add cooldowns and cost checks when starting training
- allow completing training sessions to award stats and set cooldowns
- propagate service container changes so training has access to required systems

## Testing
- `pytest tests/core/test_mission_system_rewards.py::test_complete_mission_awards_rewards -q`


------
https://chatgpt.com/codex/tasks/task_e_686aa0087af08329a13260ba1ed8b7a6